### PR TITLE
feat: add Docker environment for PostgreSQL and Elasticsearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:14-alpine
+    container_name: postgres_db
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - data_network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.14.1
+    container_name: elasticsearch_db
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
+    networks:
+      - data_network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+    driver: local
+  es_data:
+    driver: local
+
+networks:
+  data_network:
+    driver: bridge

--- a/src/config.py
+++ b/src/config.py
@@ -39,18 +39,18 @@ CMED_BASE_URL = "https://www.gov.br"
 CMED_PRICES_PAGE_URL = f"{CMED_BASE_URL}/anvisa/pt-br/assuntos/medicamentos/cmed/precos"
 
 # configurações do Banco de Dados PostgreSQL
-DB_USER = os.getenv("POSTGRES_USER", "admin")
-DB_PASSWORD = os.getenv("POSTGRES_PASSWORD", "strongpassword")
-DB_NAME = os.getenv("POSTGRES_DB", "medicamentos_db")
-DB_HOST = os.getenv("DB_HOST", "localhost")
-DB_PORT = os.getenv("DB_PORT", "5432")
+DB_USER = os.getenv("POSTGRES_USER")
+DB_PASSWORD = os.getenv("POSTGRES_PASSWORD")
+DB_NAME = os.getenv("POSTGRES_DB")
+DB_HOST = os.getenv("DB_HOST")
+DB_PORT = os.getenv("DB_PORT")
 
 # string de conexão para o SQLAlchemy
 DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 
 # configurações do Elasticsearch
-ES_HOST = os.getenv("ES_HOST", "localhost")
-ES_PORT = int(os.getenv("ES_PORT", 9200))
+ES_HOST = os.getenv("ES_HOST")
+ES_PORT = int(os.getenv("ES_PORT"))
 ES_URL = f"http://{ES_HOST}:{ES_PORT}"
 ES_INDEX_NAME = "medicamentos"
 


### PR DESCRIPTION
This commit introduces a \`docker-compose.yml\` file to easily set up and run local instances of PostgreSQL and Elasticsearch.

It also updates \`config.py\` to remove default fallback values for database and search configurations, making the setup more explicit and reliant on the \`.env\` file.